### PR TITLE
Update: decicim version 

### DIFF
--- a/lib/decidim/term_customizer/version.rb
+++ b/lib/decidim/term_customizer/version.rb
@@ -2,7 +2,7 @@
 
 module Decidim
   module TermCustomizer
-    VERSION = "0.17.1"
-    DECIDIM_VERSION = "~> 0.17.0"
+    VERSION = "0.17.2"
+    DECIDIM_VERSION = ">= 0.17.0"
   end
 end


### PR DESCRIPTION
Update `Decidim::TermCustomizer::DECIDIM_VERSION` from `~> 0.17.0` to `>= 0.17.0`

This module is used in [decidim-codit_multitenant-app](https://github.com/CodiTramuntana/decidim-codit_multitenant-app), which is being upgraded to `decidim 0.18.0`. Right now it cannot be done because of the decidim version mismatch.

I forked the module to make this change and deploy it with our demo application to ensure everything works fine before adding it to the multitenat app.