### PR TITLE
Fix ArgumentError on clear_cache

### DIFF
--- a/.github/workflows/ci_term_customizer.yml
+++ b/.github/workflows/ci_term_customizer.yml
@@ -20,4 +20,5 @@ jobs:
     needs: build_app
     name: Tests
     uses: mainio/gha-decidim-module/.github/workflows/ci_rspec.yml@main
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,11 @@ gem "puma", ">= 5.6.2"
 
 gem "faker", "~> 3.2"
 
+# Pin rexml to < 3.4 because simplecov-cobertura 2.1.0 generates XML that
+# rexml >= 3.4 rejects when parsing it back (causes "Malformed XML: No root
+# element" after the test suite finishes, breaking CI even when all tests pass).
+gem "rexml", "< 3.4"
+
 group :development, :test do
   gem "byebug", "~> 11.0", platform: :mri
   gem "dalli", "~> 2.7", ">= 2.7.10" # For testing MemCacheStore

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -650,7 +650,7 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.4.4)
+    rexml (3.3.9)
     rspec (3.13.1)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -833,6 +833,7 @@ DEPENDENCIES
   letter_opener_web (~> 2.0)
   listen (~> 3.1)
   puma (>= 5.6.2)
+  rexml (< 3.4)
   rubocop (~> 1.28)
   rubocop-faker
   rubocop-performance

--- a/lib/decidim/term_customizer/loader.rb
+++ b/lib/decidim/term_customizer/loader.rb
@@ -62,7 +62,7 @@ module Decidim
       # the resolver.
       def clear_cache
         Rails.cache.delete_matched("#{cache_key_base}/*")
-      rescue NotImplementedError, NoMethodError
+      rescue NotImplementedError, NoMethodError, ArgumentError
         # Some cache store, such as `ActiveSupport::Cache::MemCacheStore` or
         # `ActiveSupport::Cache::DalliStore` do not support `delete_matched`.
         # Therefore, clear all the possibly existing

--- a/spec/lib/decidim/term_customizer/loader_spec.rb
+++ b/spec/lib/decidim/term_customizer/loader_spec.rb
@@ -182,6 +182,74 @@ describe Decidim::TermCustomizer::Loader do
       end
     end
 
+    # FileStore implements `delete_matched` but can raise `ArgumentError` when
+    # traversing cache files whose keys contain URL-encoded sequences (e.g.
+    # ActiveStorage pre-signed S3 URLs) split across directory chunks.
+    context "when using file_store with invalid %-encoding cache files" do
+      let(:mock_cache) { ActiveSupport::Cache::MemoryStore.new }
+
+      before do
+        allow(mock_cache).to receive(:delete_matched).and_raise(ArgumentError, "invalid %-encoding")
+        allow(Rails).to receive(:cache).and_return(mock_cache)
+      end
+
+      context "without organization" do
+        let(:organization) { nil }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/system"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization" do
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization and space" do
+        let(:space) { create(:participatory_process, organization:) }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+
+      context "with organization, space and component" do
+        let(:space) { create(:participatory_process, organization:) }
+        let(:component) { create(:proposal_component, participatory_space: space) }
+
+        it "falls back to manual cache deletion without raising" do
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}"
+          )
+          expect(Rails.cache).to receive(:delete).with(
+            "decidim_term_customizer/organization_#{organization.id}/space_#{space.id}/component_#{component.id}"
+          )
+
+          expect { subject.clear_cache }.not_to raise_error
+        end
+      end
+    end
+
     # The DalliStore does not implement `delete_matched` which allows us to
     # test the `clear_cache` functionality when the cache implementation raises
     # a `NoMethodError`.


### PR DESCRIPTION
Fix ArgumentError on clear_cache when FileStore encounters URL-encoded cache keys